### PR TITLE
Renames install_gce_nexus job

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,7 +14,7 @@ resources:
 
 jobs:
 # Install nexus on gce
-  - name: install_gce_nexus
+  - name: install_gce_nexus_job
     type: runSh
     steps:
       - IN: gcp_gcloud_cli


### PR DESCRIPTION
https://github.com/devops-recipes/install_gce_nexus/issues/1

Solves https://app.shippable.com/github/devops-recipes/jobs/install_gce_nexus_rSync/builds/5b1e427108daf20700791c7b/console

Please let me know if there could be a better name for the job. 